### PR TITLE
[ptf] Improve runtime of verify_no_packet_any for large port sets

### DIFF
--- a/src/ptf-py3.patch/0006-Improve-the-runtime-of-method-verify_n.patch
+++ b/src/ptf-py3.patch/0006-Improve-the-runtime-of-method-verify_n.patch
@@ -1,0 +1,75 @@
+From bbb1b6f39d94ff9ba2efd127bc82559856ffc351 Mon Sep 17 00:00:00 2001
+From: AntonHryshchuk <antonh@nvidia.com>
+Date: Wed, 14 Jan 2026 09:42:08 +0200
+Subject: [PATCH] [testutils] improve the runtime of the method
+ verify_no_packet_any on scale ports number
+
+Signed-off-by: AntonHryshchuk <antonh@nvidia.com>
+---
+ src/ptf/testutils.py | 44 +++++++++++++++++++++++++++++++++++---------
+ 1 file changed, 35 insertions(+), 9 deletions(-)
+
+diff --git a/src/ptf/testutils.py b/src/ptf/testutils.py
+index 2ebf6a7..f355620 100755
+--- a/src/ptf/testutils.py
++++ b/src/ptf/testutils.py
+@@ -3328,21 +3328,47 @@ def verify_packets(test, pkt, ports=[], device_number=0, timeout=None, n_timeout
+     verify_no_other_packets(test, device_number=device_number, timeout=n_timeout)
+ 
+ 
+-def verify_no_packet_any(test, pkt, ports=[], device_number=0, timeout=None):
++def verify_no_packet_any(test, pkt, ports=[], device_number=0, timeout=1):
+     """
+-    Check that a packet is NOT received on _any_ of the specified ports belonging to
+-    the given device (default device_number is 0).
++    Verify that a packet is NOT received on any of the specified ports belonging to
++    the given device within the given timeout. Uses a single global timeout and repeatedly
++    polls all ports with zero per-port timeout.
++    Raises:
++        test.fail if the packet is received on any of the specified ports.
+     """
+     test.assertTrue(
+         len(ports) != 0,
+         "No port available to validate receiving packet on device %d, " % device_number,
+     )
+-    for device, port in ptf_ports():
+-        if device != device_number:
+-            continue
+-        if port in ports:
+-            print("verifying packet on port device", device_number, "port", port)
+-            verify_no_packet(test, pkt, (device, port), timeout=timeout)
++    ports = list(ports)
++    logging.debug("Negative check for pkt on device %d, ports %s", device_number, ports)
++    start = time.monotonic()
++    while True:
++        remaining = timeout - (time.monotonic() - start)
++        if remaining <= 0:
++            return  # PASS - packet not observed within timeout window
++
++        for device, port in ptf_ports():
++            if device != device_number or port not in ports:
++                continue
++
++            result = dp_poll(
++                test,
++                device_number=device_number,
++                port_number=port,
++                timeout=0,  # non-blocking poll
++                exp_pkt=pkt,
++            )
++
++            if isinstance(result, test.dataplane.PollSuccess):
++                test.fail(
++                    "Unexpected packet received on device %d, port %d"
++                    % (device_number, port)
++                )
++
++        # Small sleep to avoid busy-looping and excessive CPU usage.
++        # Also gives dataplane threads time to enqueue incoming packets.
++        time.sleep(0.05)
+ 
+ 
+ def verify_packets_any(
+-- 
+2.45.1
+

--- a/src/ptf-py3.patch/series
+++ b/src/ptf-py3.patch/series
@@ -3,3 +3,4 @@
 0003-Avoid-local-version-scheme-by-setuptools-scm.patch
 0004-Consider-only-expected-packets-for-timeout.patch
 0005-Fix-a-multithreading-issue-in-writing-pcap-files-204.patch
+0006-Improve-the-runtime-of-method-verify_n.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To reduce the runtime of tests


#### How I did it

Created PR for PTF repository, and added a patch to sonic-buildimage
https://github.com/p4lang/ptf/pull/231
#### How to verify it
Run drop_packets tests in sonic-mgmt.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

